### PR TITLE
Chore: Upgrade docker specs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,13 +8,15 @@
   "workspaceFolder": "/utkusarioglu/templates/diagram-repo-template",
   "settings": {
     "workbench.colorCustomizations": {
-      "activityBar.background": "#5f003f"
+      "activityBar.background": "#ff0000",
+      "activityBar.foreground": "#000000"
     }
   },
-  "extensions": [
-    "jebbs.plantuml"
-  ],
-  "features": {
-    "github-cli": "latest"
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "jebbs.plantuml"
+      ]
+    }
   }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,14 +1,19 @@
 version: "3.9"
 services:
   diagram-repo-template:
+    environment:
+      GH_TOKEN: ${GH_TOKEN}
     volumes:
-      # vscode
-      - vscode-exts:/root/.vscode-server/extensions
-      - vscode-exts-insiders:/root/.vscode-server-insiders/extensions
-      # github cli
-      - ~/.config/gh:/home/plantuml/.config/gh:ro
+      - type: volume
+        source: vscode-server-extensions
+        target: /home/plantuml/.vscode-server/extensions
+      - type: volume
+        source: vscode-server-insiders-extensions
+        target: /home/plantuml/.vscode-server-insiders/extensions
     command: /bin/sh -c "while sleep 1000; do :; done"
 
 volumes:
-  vscode-exts:
-  vscode-exts-insiders:
+  vscode-server-extensions:
+    name: diagram-repo-template-vscode-server-extensions
+  vscode-server-insiders-extensions:
+    name: diagram-repo-template-vscode-server-insiders-extensions

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -1,6 +1,8 @@
 version: "3.9"
 services:
   diagram-repo-template:
-    image: utkusarioglu/plantuml-devcontainer:1.0.0
+    image: utkusarioglu/plantuml-devcontainer:1.0.4
     volumes:
-      - ..:/utkusarioglu/templates/diagram-repo-template
+      - type: bind
+        source: ..
+        target: /utkusarioglu/templates/diagram-repo-template


### PR DESCRIPTION
- Upgrade to devcontainer image 1.0.4. This new version is a
  devcontainer.
- Remove devcontainer features from `devcontainer.json` as these now
  come with the devcontainer image.
- Alter the colors of the VS Code activity bar in accordance with the
  template repo conventions.
- Refactor docker volumes to use the long syntax.
- Remove gh config volume bind in favor of `GH_TOKEN` environment
  variable for gh cli config.
